### PR TITLE
TT Move Ordering

### DIFF
--- a/src/games/three_check.rs
+++ b/src/games/three_check.rs
@@ -224,8 +224,12 @@ impl ThreeCheckState {
             board.zkey.toggle_stm();
         }
 
-        board.zkey.toggle_check(Color::White, board.check_count(Color::White));
-        board.zkey.toggle_check(Color::Black, board.check_count(Color::Black));
+        board
+            .zkey
+            .toggle_check(Color::White, board.check_count(Color::White));
+        board
+            .zkey
+            .toggle_check(Color::Black, board.check_count(Color::Black));
 
         Some(board)
     }
@@ -455,7 +459,7 @@ impl ThreeCheckState {
             | (attacks::rook_attacks(sq, occ) & hvs)
     }
 
-    pub fn is_drawn(&self/*, keys: Vec<ZobristKey>*/) -> bool {
+    pub fn is_drawn(&self /*, keys: Vec<ZobristKey>*/) -> bool {
         if self.half_move_clock >= 100 {
             return true;
         }
@@ -628,7 +632,7 @@ impl CopyMakeBoard for ThreeCheckState {
     // broken for now
     fn game_result(&self) -> super::board::GameResult {
         // if self.is_drawn() {
-            // return GameResult::DRAW;
+        // return GameResult::DRAW;
         // }
 
         if self.check_count(self.stm()) >= 3 {

--- a/src/games/three_check.rs
+++ b/src/games/three_check.rs
@@ -2,12 +2,14 @@ pub mod attacks;
 mod castling_rooks;
 mod movegen;
 pub mod types;
+mod zobrist;
 
 use core::fmt;
 
 use castling_rooks::CastlingRooks;
 pub use movegen::MoveList;
 pub use types::{Bitboard, Color, Move, MoveKind, Piece, PieceType, Square};
+pub use zobrist::ZobristKey;
 
 use super::board::{CopyMakeBoard, CopyMakeWrapper, GameResult};
 
@@ -23,7 +25,8 @@ pub struct ThreeCheckState {
     stm: Color,
     ep_square: Option<Square>,
     half_move_clock: u8,
-    check_count: [u8; 2], // zkey: ZobristKey,
+    check_count: [u8; 2],
+    zkey: ZobristKey,
 }
 
 impl ThreeCheckState {
@@ -212,14 +215,17 @@ impl ThreeCheckState {
         }
 
         board.update_check_info();
-        /*board.zkey.toggle_castle_rights(board.castling_rooks());
+        board.zkey.toggle_castle_rights(board.castling_rooks());
         if let Some(ep_square) = board.ep_square() {
             board.zkey.toggle_ep_square(ep_square);
         }
 
         if board.stm() == Color::Black {
             board.zkey.toggle_stm();
-        }*/
+        }
+
+        board.zkey.toggle_check(Color::White, board.check_count(Color::White));
+        board.zkey.toggle_check(Color::Black, board.check_count(Color::Black));
 
         Some(board)
     }
@@ -283,10 +289,10 @@ impl ThreeCheckState {
     }
 
     pub fn make_move(&mut self, mv: Move) {
-        /*if let Some(ep_square) = self.ep_square() {
+        if let Some(ep_square) = self.ep_square() {
             self.zkey.toggle_ep_square(ep_square);
         }
-        self.zkey.toggle_castle_rights(self.castling_rooks);*/
+        self.zkey.toggle_castle_rights(self.castling_rooks);
 
         let from = mv.from_sq();
         let to = mv.to_sq();
@@ -352,16 +358,18 @@ impl ThreeCheckState {
 
         self.stm = self.stm.flip();
 
-        /*if let Some(ep_square) = self.ep_square() {
+        if let Some(ep_square) = self.ep_square() {
             self.zkey.toggle_ep_square(ep_square);
         }
         self.zkey.toggle_castle_rights(self.castling_rooks);
-        self.zkey.toggle_stm();*/
+        self.zkey.toggle_stm();
 
         self.update_check_info();
 
         if self.checkers().any() {
+            self.zkey.toggle_check(self.stm, self.check_count(self.stm));
             self.check_count[self.stm as usize] += 1;
+            self.zkey.toggle_check(self.stm, self.check_count(self.stm));
         }
     }
 
@@ -447,7 +455,7 @@ impl ThreeCheckState {
             | (attacks::rook_attacks(sq, occ) & hvs)
     }
 
-    pub fn is_drawn(&self /*, keys: &Vec<ZobristKey>*/) -> bool {
+    pub fn is_drawn(&self/*, keys: Vec<ZobristKey>*/) -> bool {
         if self.half_move_clock >= 100 {
             return true;
         }
@@ -489,7 +497,7 @@ impl ThreeCheckState {
         self.ep_square
     }
 
-    /*pub fn zkey(&self) -> ZobristKey {
+    pub fn zkey(&self) -> ZobristKey {
         self.zkey
     }
 
@@ -508,8 +516,10 @@ impl ThreeCheckState {
         if self.stm() == Color::Black {
             key.toggle_stm();
         }
+        key.toggle_check(Color::White, self.check_count(Color::White));
+        key.toggle_check(Color::Black, self.check_count(Color::Black));
         key
-    }*/
+    }
 
     fn empty() -> ThreeCheckState {
         Self {
@@ -524,7 +534,7 @@ impl ThreeCheckState {
             ep_square: None,
             half_move_clock: 0,
             check_count: [0; 2],
-            // zkey: ZobristKey::new(),
+            zkey: ZobristKey::new(),
         }
     }
 
@@ -534,7 +544,7 @@ impl ThreeCheckState {
         self.colors[piece.color() as usize] |= sq_bb;
         self.squares[sq.value() as usize] = Some(piece);
 
-        // self.zkey.toggle_piece(piece, sq);
+        self.zkey.toggle_piece(piece, sq);
     }
 
     fn remove_piece(&mut self, sq: Square) {
@@ -544,7 +554,7 @@ impl ThreeCheckState {
         self.colors[piece.color() as usize] ^= sq_bb;
         self.squares[sq.value() as usize] = None;
 
-        // self.zkey.toggle_piece(piece, sq);
+        self.zkey.toggle_piece(piece, sq);
     }
 
     fn move_piece(&mut self, from: Square, to: Square) {
@@ -555,8 +565,8 @@ impl ThreeCheckState {
         self.squares[from.value() as usize] = None;
         self.squares[to.value() as usize] = Some(piece);
 
-        // self.zkey.toggle_piece(piece, from);
-        // self.zkey.toggle_piece(piece, to);
+        self.zkey.toggle_piece(piece, from);
+        self.zkey.toggle_piece(piece, to);
     }
 
     fn update_check_info(&mut self) {
@@ -615,10 +625,11 @@ impl CopyMakeBoard for ThreeCheckState {
         Self::from_fen(fen)
     }
 
+    // broken for now
     fn game_result(&self) -> super::board::GameResult {
-        if self.is_drawn() {
-            return GameResult::DRAW;
-        }
+        // if self.is_drawn() {
+            // return GameResult::DRAW;
+        // }
 
         if self.check_count(self.stm()) >= 3 {
             return GameResult::LOSS;

--- a/src/games/three_check/types.rs
+++ b/src/games/three_check/types.rs
@@ -156,8 +156,6 @@ pub struct Move {
 }
 
 impl Move {
-    pub const NULL: Move = Move { data: 0 };
-
     const fn new(from: Square, to: Square, kind: MoveKind, promo: u8) -> Self {
         Self {
             data: from.value()

--- a/src/games/three_check/zobrist.rs
+++ b/src/games/three_check/zobrist.rs
@@ -1,5 +1,5 @@
-use super::{Color, Piece, Square};
 use super::CastlingRooks;
+use super::{Color, Piece, Square};
 
 // lol
 const fn xorshift64(mut x: u64) -> u64 {
@@ -13,7 +13,7 @@ struct ZobristKeys {
     piece_squares: [[u64; 12]; 64],
     castling_rights: [u64; 16],
     enpassant: [u64; 8],
-	checks: [[u64; 4]; 2],
+    checks: [[u64; 4]; 2],
     stm: u64,
 }
 
@@ -22,7 +22,7 @@ const ZOBRIST_KEYS: ZobristKeys = {
         piece_squares: [[0; 12]; 64],
         castling_rights: [0; 16],
         enpassant: [0; 8],
-		checks: [[0; 4]; 2],
+        checks: [[0; 4]; 2],
         stm: 0,
     };
 
@@ -54,12 +54,12 @@ const ZOBRIST_KEYS: ZobristKeys = {
         i += 1;
     }
 
-	let mut i = 0;
-	while i < 8 {
-		result.checks[i / 4][i % 4] = rand;
-		rand = xorshift64(rand);
-		i += 1;
-	}
+    let mut i = 0;
+    while i < 8 {
+        result.checks[i / 4][i % 4] = rand;
+        rand = xorshift64(rand);
+        i += 1;
+    }
 
     result.stm = rand;
 
@@ -90,9 +90,9 @@ impl ZobristKey {
         self.0 ^= ZOBRIST_KEYS.enpassant[ep_square.file() as usize];
     }
 
-	pub fn toggle_check(&mut self, color: Color, checks: u8) {
-		self.0 ^= ZOBRIST_KEYS.checks[color as usize][checks as usize];
-	}
+    pub fn toggle_check(&mut self, color: Color, checks: u8) {
+        self.0 ^= ZOBRIST_KEYS.checks[color as usize][checks as usize];
+    }
 
     pub fn value(self) -> u64 {
         self.0

--- a/src/games/three_check/zobrist.rs
+++ b/src/games/three_check/zobrist.rs
@@ -1,0 +1,100 @@
+use super::{Color, Piece, Square};
+use super::CastlingRooks;
+
+// lol
+const fn xorshift64(mut x: u64) -> u64 {
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    x
+}
+
+struct ZobristKeys {
+    piece_squares: [[u64; 12]; 64],
+    castling_rights: [u64; 16],
+    enpassant: [u64; 8],
+	checks: [[u64; 4]; 2],
+    stm: u64,
+}
+
+const ZOBRIST_KEYS: ZobristKeys = {
+    let mut result = ZobristKeys {
+        piece_squares: [[0; 12]; 64],
+        castling_rights: [0; 16],
+        enpassant: [0; 8],
+		checks: [[0; 4]; 2],
+        stm: 0,
+    };
+
+    let mut rand = 0x3519A84F;
+    rand = xorshift64(rand);
+
+    let mut i = 0;
+    while i < 64 {
+        let mut j = 0;
+        while j < 12 {
+            result.piece_squares[i][j] = rand;
+            rand = xorshift64(rand);
+            j += 1;
+        }
+        i += 1;
+    }
+
+    let mut i = 0;
+    while i < 16 {
+        result.castling_rights[i] = rand;
+        rand = xorshift64(rand);
+        i += 1;
+    }
+
+    let mut i = 0;
+    while i < 8 {
+        result.enpassant[i] = rand;
+        rand = xorshift64(rand);
+        i += 1;
+    }
+
+	let mut i = 0;
+	while i < 8 {
+		result.checks[i / 4][i % 4] = rand;
+		rand = xorshift64(rand);
+		i += 1;
+	}
+
+    result.stm = rand;
+
+    result
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ZobristKey(u64);
+
+impl ZobristKey {
+    pub fn new() -> Self {
+        Self(0)
+    }
+
+    pub fn toggle_stm(&mut self) {
+        self.0 ^= ZOBRIST_KEYS.stm;
+    }
+
+    pub fn toggle_piece(&mut self, piece: Piece, square: Square) {
+        self.0 ^= ZOBRIST_KEYS.piece_squares[square.value() as usize][piece as usize];
+    }
+
+    pub fn toggle_castle_rights(&mut self, castle_rooks: CastlingRooks) {
+        self.0 ^= ZOBRIST_KEYS.castling_rights[castle_rooks.right_bits() as usize];
+    }
+
+    pub fn toggle_ep_square(&mut self, ep_square: Square) {
+        self.0 ^= ZOBRIST_KEYS.enpassant[ep_square.file() as usize];
+    }
+
+	pub fn toggle_check(&mut self, color: Color, checks: u8) {
+		self.0 ^= ZOBRIST_KEYS.checks[color as usize][checks as usize];
+	}
+
+    pub fn value(self) -> u64 {
+        self.0
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,6 @@ pub fn parse_move(board: &ThreeCheckBoard, str: &str) -> three_check::Move {
         }
     }
     panic!("WTF {}", str);
-    three_check::Move::NULL
 }
 
 fn parse_startpos(curr_board: &mut ThreeCheckBoard, toks: &mut SplitWhitespace<'_>) {
@@ -77,6 +76,7 @@ fn select_random_move(board: &ThreeCheckBoard) -> three_check::Move {
 
 fn run_three_check() {
     let mut curr_board = ThreeCheckBoard::startpos();
+    let mut search = ThreeCheckSearch::new();
     loop {
         let mut command = String::new();
         stdin().read_line(&mut command).expect("Bad input");
@@ -93,7 +93,7 @@ fn run_three_check() {
                 println!("readyok");
             }
             Some("ucinewgame") => {
-                // empty for now
+                search.clear();
             }
             Some("position") => match toks.next() {
                 Some("startpos") => {
@@ -107,7 +107,6 @@ fn run_three_check() {
                 }
             },
             Some("go") => {
-                let mut search = ThreeCheckSearch::new();
                 let mut limits = SearchLimits::default();
                 loop {
                     match toks.next() {


### PR DESCRIPTION
```
Score of calamity-tt-move-ordering vs calamity-check-ext: 174 - 70 - 4  [0.710] 248
...      calamity-tt-move-ordering playing White: 87 - 35 - 3  [0.708] 125
...      calamity-tt-move-ordering playing Black: 87 - 35 - 1  [0.711] 123
...      White vs Black: 122 - 122 - 4  [0.500] 248
Elo difference: 155.3 +/- 47.5, LOS: 100.0 %, DrawRatio: 1.6 %
SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted
```
tc: 8+0.08
book: noob_3moves.epd
sprt bounds: [0, 10]