### PR TITLE
Three Check: Reverse Futility Pruning

### DIFF
--- a/src/search/three_check.rs
+++ b/src/search/three_check.rs
@@ -111,6 +111,16 @@ impl ThreeCheckSearch {
             return ThreeCheckEval::evaluate(board);
         }
 
+        let in_check = board.curr_state().checkers().any();
+        let root = ply == 0;
+
+        if !in_check && !root {
+            let static_eval = ThreeCheckEval::evaluate(board);
+            if depth <= 4 && static_eval - 100 * depth >= beta {
+                return static_eval;
+            }
+        }
+
         let mut moves = board.gen_moves();
         if moves.len() == 0 {
             if board.curr_state().checkers().any() {


### PR DESCRIPTION
```
Score of calamity-rfp vs calamity-tt-move-ordering: 287 - 182 - 21  [0.607] 490
...      calamity-rfp playing White: 154 - 80 - 11  [0.651] 245
...      calamity-rfp playing Black: 133 - 102 - 10  [0.563] 245
...      White vs Black: 256 - 213 - 21  [0.544] 490
Elo difference: 75.6 +/- 30.8, LOS: 100.0 %, DrawRatio: 4.3 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted
```
tc: 8+0.08
book: noob_3moves.epd
sprt bounds: [0, 10]