### PR TITLE
Three Check: TT Cutoffs

### DIFF
--- a/src/games/three_check.rs
+++ b/src/games/three_check.rs
@@ -377,6 +377,19 @@ impl ThreeCheckState {
         }
     }
 
+    pub fn make_null_move(&mut self) {
+        self.half_move_clock += 1;
+        if let Some(ep) = self.ep_square {
+            self.zkey.toggle_ep_square(ep);
+        }
+        self.zkey.toggle_stm();
+        self.ep_square = None;
+
+        self.stm = self.stm.flip();
+
+        self.update_check_info();
+    }
+
     pub fn stm(&self) -> Color {
         self.stm
     }
@@ -657,7 +670,11 @@ impl CopyMakeBoard for ThreeCheckState {
     }
 
     fn make_move(&mut self, mv: Self::Move) -> bool {
-        self.make_move(mv);
+        if mv == Move::NULL {
+            self.make_null_move();
+        } else {
+            self.make_move(mv);
+        }
         true
     }
 

--- a/src/games/three_check/types.rs
+++ b/src/games/three_check/types.rs
@@ -156,6 +156,8 @@ pub struct Move {
 }
 
 impl Move {
+    pub const NULL: Self = Self { data: 0 };
+
     const fn new(from: Square, to: Square, kind: MoveKind, promo: u8) -> Self {
         Self {
             data: from.value()


### PR DESCRIPTION
```
Score of calamity-tt-cutoffs vs calamity-rfp: 349 - 241 - 22  [0.588] 612
...      calamity-tt-cutoffs playing White: 196 - 99 - 11  [0.658] 306
...      calamity-tt-cutoffs playing Black: 153 - 142 - 11  [0.518] 306
...      White vs Black: 338 - 252 - 22  [0.570] 612
Elo difference: 62.0 +/- 27.5, LOS: 100.0 %, DrawRatio: 3.6 %
SPRT: llr 2.97 (100.7%), lbound -2.94, ubound 2.94 - H1 was accepted
```
tc: 8+0.08
book: noob_3moves.epd
sprt bounds: [0, 10]