### PR TITLE
Three Check: History move ordering

### DIFF
--- a/src/search/three_check.rs
+++ b/src/search/three_check.rs
@@ -178,7 +178,7 @@ impl ThreeCheckSearch {
 
         for mv in moves.iter() {
             let mv = *mv;
-            let capture = board.piece_on(mv.to_sq()).is_none();
+            let capture = board.piece_on(mv.to_sq()).is_some();
             // three_check uses legal movegen
             board.make_move(mv);
             self.nodes += 1;


### PR DESCRIPTION
```
Score of calamity-history vs calamity-mobility: 217 - 112 - 7  [0.656] 336
...      calamity-history playing White: 106 - 57 - 5  [0.646] 168
...      calamity-history playing Black: 111 - 55 - 2  [0.667] 168
...      White vs Black: 161 - 168 - 7  [0.490] 336
Elo difference: 112.3 +/- 38.8, LOS: 100.0 %, DrawRatio: 2.1 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```
tc: 8+0.08
book: noob_3moves.epd
sprt bounds: [0, 10]