### PR TITLE
Three Check: Safe checks evaluation

### DIFF
--- a/src/eval/three_check.rs
+++ b/src/eval/three_check.rs
@@ -129,10 +129,10 @@ fn evaluate_king(state: &ThreeCheckState, eval_data: &EvalData, color: Color) {
     let queen_checks = bishop_checks | rook_checks;
 
     let mut eval = 0;
-    eval += 200 * (knight_checks & eval_data.attacked_by[color as usize][PieceType::Knight as usize] & safe).popcount();
-    eval += 200 * (bishop_checks & eval_data.attacked_by[color as usize][PieceType::Bishop as usize] & safe).popcount();
-    eval += 200 * (rook_checks & eval_data.attacked_by[color as usize][PieceType::Rook as usize] & safe).popcount();
-    eval += 200 * (queen_checks & eval_data.attacked_by[color as usize][PieceType::Queen as usize] & safe).popcount();
+    eval += 30 * (knight_checks & eval_data.attacked_by[color as usize][PieceType::Knight as usize] & safe).popcount();
+    eval += 30 * (bishop_checks & eval_data.attacked_by[color as usize][PieceType::Bishop as usize] & safe).popcount();
+    eval += 50 * (rook_checks & eval_data.attacked_by[color as usize][PieceType::Rook as usize] & safe).popcount();
+    eval += 50 * (queen_checks & eval_data.attacked_by[color as usize][PieceType::Queen as usize] & safe).popcount();
 }
 
 #[derive(Debug, Default, Clone, Copy)]


### PR DESCRIPTION
```
Score of calamity-safe-checks vs calamity-qsearch: 280 - 175 - 22  [0.610] 477
...      calamity-safe-checks playing White: 154 - 72 - 13  [0.672] 239
...      calamity-safe-checks playing Black: 126 - 103 - 9  [0.548] 238
...      White vs Black: 257 - 198 - 22  [0.562] 477
Elo difference: 77.8 +/- 31.2, LOS: 100.0 %, DrawRatio: 4.6 %
SPRT: llr 2.97 (100.8%), lbound -2.94, ubound 2.94 - H1 was accepted
```
tc: 8+0.08
book: noob_3moves.epd
sprt bounds: [0, 10]