### PR TITLE
Three Check: Late move reductions

### DIFF
--- a/src/search/three_check.rs
+++ b/src/search/three_check.rs
@@ -263,9 +263,23 @@ impl ThreeCheckSearch {
 
             let mut score = 0;
             let new_depth = depth - 1 + gives_check as i32;
-            if !PV || moves_played > 1 {
+            if moves_played >= 4 && depth >= 3 && !capture && !gives_check {
+                let reduction = 1;
+                score = -self.alpha_beta::<false>(
+                    board,
+                    new_depth - reduction,
+                    ply + 1,
+                    -alpha - 1,
+                    -alpha,
+                );
+                if score > alpha && reduction > 0 {
+                    score =
+                        -self.alpha_beta::<false>(board, new_depth, ply + 1, -alpha - 1, -alpha);
+                }
+            } else if !PV || moves_played > 1 {
                 score = -self.alpha_beta::<false>(board, new_depth, ply + 1, -alpha - 1, -alpha);
             }
+
             if PV && (moves_played == 1 || score > alpha) {
                 score = -self.alpha_beta::<true>(board, new_depth, ply + 1, -beta, -alpha);
             }
@@ -340,8 +354,13 @@ impl Search<ThreeCheckBoard> for ThreeCheckSearch {
         let mut best_move = None;
         for depth in 1..max_depth {
             self.root_depth = depth;
-            let iter_score =
-                self.alpha_beta::<true>(&mut tmp_board, depth, 0, -Self::SCORE_WIN, Self::SCORE_WIN);
+            let iter_score = self.alpha_beta::<true>(
+                &mut tmp_board,
+                depth,
+                0,
+                -Self::SCORE_WIN,
+                Self::SCORE_WIN,
+            );
             if self.stop {
                 break;
             }


### PR DESCRIPTION
```
Score of calamity-lmr vs calamity-pvs: 710 - 591 - 46  [0.544] 1347
...      calamity-lmr playing White: 389 - 260 - 25  [0.596] 674
...      calamity-lmr playing Black: 321 - 331 - 21  [0.493] 673
...      White vs Black: 720 - 581 - 46  [0.552] 1347
Elo difference: 30.8 +/- 18.3, LOS: 100.0 %, DrawRatio: 3.4 %
SPRT: llr 2.97 (100.9%), lbound -2.94, ubound 2.94 - H1 was accepted
```
tc: 8+0.08
book: noob_3moves.epd
sprt bounds: [0, 10]