### PR TITLE
Three Check: Log-formula LMR

### DIFF
--- a/src/search/three_check.rs
+++ b/src/search/three_check.rs
@@ -264,7 +264,8 @@ impl ThreeCheckSearch {
             let mut score = 0;
             let new_depth = depth - 1 + gives_check as i32;
             if moves_played >= 4 && depth >= 3 && !capture && !gives_check {
-                let reduction = 1;
+                let reduction =
+                    (0.77 + (moves_played as f64).ln() * (depth as f64).ln() / 2.36) as i32;
                 score = -self.alpha_beta::<false>(
                     board,
                     new_depth - reduction,


### PR DESCRIPTION
Use the old viri-values ™️ 
```
Score of calamity-log-lmr vs calamity-lmr: 548 - 437 - 71  [0.553] 1056
...      calamity-log-lmr playing White: 300 - 193 - 36  [0.601] 529
...      calamity-log-lmr playing Black: 248 - 244 - 35  [0.504] 527
...      White vs Black: 544 - 441 - 71  [0.549] 1056
Elo difference: 36.7 +/- 20.3, LOS: 100.0 %, DrawRatio: 6.7 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
```
tc: 8+0.8
book: noob_3moves.epd
sprt bounds: [0, 10]