### PR TITLE
Three Check: Bonus for unsafe checks

### DIFF
--- a/src/eval/three_check.rs
+++ b/src/eval/three_check.rs
@@ -151,12 +151,14 @@ fn evaluate_king(state: &ThreeCheckState, eval_data: &EvalData, color: Color) ->
     bishop_checks &= eval_data.attacked_by[color as usize][PieceType::Bishop as usize];
     rook_checks &= eval_data.attacked_by[color as usize][PieceType::Rook as usize];
     queen_checks &= eval_data.attacked_by[color as usize][PieceType::Queen as usize];
+    let all_checks = knight_checks | bishop_checks | rook_checks | queen_checks;
 
     let mut eval = 0;
     eval += 50 * (knight_checks & safe).popcount() as i32;
     eval += 50 * (bishop_checks & safe).popcount() as i32;
     eval += 70 * (rook_checks & safe).popcount() as i32;
     eval += 90 * (queen_checks & safe).popcount() as i32;
+    eval += 40 * (all_checks & !safe).popcount() as i32;
     eval
 }
 


### PR DESCRIPTION
```
Score of calamity-unsafe-checks vs calamity-fp: 481 - 372 - 64  [0.559] 917
...      calamity-unsafe-checks playing White: 252 - 175 - 32  [0.584] 459
...      calamity-unsafe-checks playing Black: 229 - 197 - 32  [0.535] 458
...      White vs Black: 449 - 404 - 64  [0.525] 917
Elo difference: 41.5 +/- 21.8, LOS: 100.0 %, DrawRatio: 7.0 %
SPRT: llr 2.97 (100.8%), lbound -2.94, ubound 2.94 - H1 was accepted
```
tc: 8+0.08
book: noob_3moves.epd
sprt bounds: [0, 10]