### PR TITLE
Three Check: Scale king safety by number of checks

### DIFF
--- a/src/eval/three_check.rs
+++ b/src/eval/three_check.rs
@@ -159,7 +159,7 @@ fn evaluate_king(state: &ThreeCheckState, eval_data: &EvalData, color: Color) ->
     eval += 70 * (rook_checks & safe).popcount() as i32;
     eval += 90 * (queen_checks & safe).popcount() as i32;
     eval += 40 * (all_checks & !safe).popcount() as i32;
-    eval
+    eval * (2 + state.check_count(color.flip()) as i32) / 2
 }
 
 #[derive(Debug, Default, Clone, Copy)]


### PR DESCRIPTION
```
Score of calamity-scale-ks vs calamity-unsafe-checks: 827 - 709 - 139  [0.535] 1675
...      calamity-scale-ks playing White: 457 - 317 - 64  [0.584] 838
...      calamity-scale-ks playing Black: 370 - 392 - 75  [0.487] 837
...      White vs Black: 849 - 687 - 139  [0.548] 1675
Elo difference: 24.5 +/- 16.0, LOS: 99.9 %, DrawRatio: 8.3 %
SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted
```
tc: 8+0.08
book: noob_3moves.epd
sprt bounds: [0, 10]