### PR TITLE
Three Check: Aspiration windows

### DIFF
--- a/src/search/three_check.rs
+++ b/src/search/three_check.rs
@@ -337,6 +337,38 @@ impl ThreeCheckSearch {
         best_score
     }
 
+    fn asp_windows(&mut self, board: &mut ThreeCheckBoard, depth: i32, prev_score: i32) -> i32 {
+        let mut alpha = -Self::SCORE_WIN;
+        let mut beta = Self::SCORE_WIN;
+        let mut delta = 30;
+        if depth >= 5 {
+            alpha = prev_score - delta;
+            beta = prev_score + delta;
+        }
+        loop {
+            let iter_score = self.alpha_beta::<true>(
+                board,
+                depth,
+                0,
+                alpha,
+                beta,
+            );
+
+            if self.stop {
+                return 0;
+            }
+
+            if alpha < iter_score && iter_score < beta {
+                return iter_score;
+            } else if iter_score <= alpha {
+                alpha = iter_score - delta;
+            } else {
+                beta = iter_score + delta;
+            }
+            delta *= 2;
+        }
+    }
+
     pub fn clear(&mut self) {
         self.tt.clear();
     }
@@ -364,13 +396,7 @@ impl Search<ThreeCheckBoard> for ThreeCheckSearch {
         let mut best_move = None;
         for depth in 1..max_depth {
             self.root_depth = depth;
-            let iter_score = self.alpha_beta::<true>(
-                &mut tmp_board,
-                depth,
-                0,
-                -Self::SCORE_WIN,
-                Self::SCORE_WIN,
-            );
+            let iter_score = self.asp_windows(&mut tmp_board, depth, score);
             if self.stop {
                 break;
             }


### PR DESCRIPTION
```
Score of calamity-asp-windows vs calamity-attack-weight: 270 - 169 - 38  [0.606] 477
...      calamity-asp-windows playing White: 150 - 74 - 15  [0.659] 239
...      calamity-asp-windows playing Black: 120 - 95 - 23  [0.553] 238
...      White vs Black: 245 - 194 - 38  [0.553] 477
Elo difference: 74.7 +/- 30.6, LOS: 100.0 %, DrawRatio: 8.0 %
SPRT: llr 2.96 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted
```
tc: 8+0.08
book: noob_3moves.epd
sprt bounds: [0, 10]