### PR TITLE
Three Check: SEE Pruning

### DIFF
--- a/src/search/three_check.rs
+++ b/src/search/three_check.rs
@@ -260,12 +260,17 @@ impl ThreeCheckSearch {
         for mv in moves.iter() {
             let mv = *mv;
             let capture = board.piece_on(mv.to_sq()).is_some();
+            let see_prune = !root && best_score > -Self::SCORE_WIN + 128 && !see::see(board.curr_state(), mv, -150 * depth);
             // three_check uses legal movegen
             board.make_move(mv);
             let gives_check = board.curr_state().checkers().any();
 
-            if !root && best_score > -Self::SCORE_WIN + 128 && !capture && !gives_check {
-                if !in_check && depth <= 4 && static_eval + 100 + 150 * depth <= alpha {
+            if !root && best_score > -Self::SCORE_WIN + 128 && !gives_check {
+                if !in_check && see_prune {
+                    board.unmake_move();
+                    continue;
+                }
+                if !in_check && !capture && depth <= 4 && static_eval + 100 + 150 * depth <= alpha {
                     board.unmake_move();
                     continue;
                 }


### PR DESCRIPTION
```
Score of calamity-see-pruning vs calamity-qs-see-pruning: 431 - 327 - 90  [0.561] 848
...      calamity-see-pruning playing White: 246 - 140 - 38  [0.625] 424
...      calamity-see-pruning playing Black: 185 - 187 - 52  [0.498] 424
...      White vs Black: 433 - 325 - 90  [0.564] 848
Elo difference: 42.8 +/- 22.3, LOS: 100.0 %, DrawRatio: 10.6 %
SPRT: llr 2.96 (100.6%), lbound -2.94, ubound 2.94 - H1 was accepted
```
tc: 8+0.08
book: noob_3moves.epd
sprt bounds: [0, 10]